### PR TITLE
Ring fixes

### DIFF
--- a/Lua/Rings/LUA_RINGSYS.lua
+++ b/Lua/Rings/LUA_RINGSYS.lua
@@ -320,6 +320,8 @@ local function K_RingGainEFX(source, amount)
 		-- Increase ringCount and reset state
 
 		if source.ringpt.ringCount + amount > 10 then
+			source.ringpt.ringCount = 10
+			source.ringpt.tics = max(source.ringpt.tics, states[S_RINGPOINT].tics - rintPointAnimationResetFrame)
 			spawnRingPoint(source, source.ringpt.ringCount + amount - 10)
 			return
 		end

--- a/Lua/Rings/LUA_RINGSYS.lua
+++ b/Lua/Rings/LUA_RINGSYS.lua
@@ -1206,13 +1206,16 @@ addHook("NetVars", function(n)
 end)
 
 addHook("TouchSpecial", function(mo, t)
-	if ((t) and (t.player))
-		local p = t.player
-		if ((p.numRings ~= nil) and (getTotalRings(p) < rings.ringcap))
-			doRingAward(p, 1, true)
-		end
-		p = nil
+	if not ((t) and (t.player)) then
+		return true
 	end
+
+	local p = t.player
+	if not ((p.numRings ~= nil) and (getTotalRings(p) < rings.ringcap)) then
+		return true
+	end
+
+	doRingAward(p, 1, true)
 end, MT_RINGSO)
 
 addHook("MobjCollide", function(tm, mo)


### PR DESCRIPTION
Fixes the ring popup to show the correct value (10) when a rollover occures.
Also changes the dropped ring pickups from itemboxes and players to no longer be removed if a player who has max rings picks them up.