### PR TITLE
Fix sting alert desync

### DIFF
--- a/Lua/Rings/LUA_RINGSYS.lua
+++ b/Lua/Rings/LUA_RINGSYS.lua
@@ -1139,7 +1139,7 @@ addHook("MobjThinker", function(mo)
 		local finY = targ.y + (P_RandomRange(-jitter, jitter) * mos)
 		local finZ = targ.z + ((targ.height*3)/2) + (P_RandomRange(-jitter, jitter) * mos)
 		//rgs_hideAlert(mo, p)
-		brg_alertVisibilityLogic(mo.target.player, mo)
+		brg_alertVisibilityLogic(p, mo)
 		mo.noTargBuffer = 0
 		mo.colorized = true
 		mo.color = targ.color
@@ -1148,8 +1148,9 @@ addHook("MobjThinker", function(mo)
 		finX = nil
 		finY = nil
 		finZ = nil
-		if (mo.target.player.playerstate == PST_DEAD)
-			mo.target.player.stingAlertMobj = nil
+		if (p.playerstate == PST_DEAD)
+			local rs = getRingstuff(p)
+			rs.stingAlertMobj = nil
 			P_RemoveMobj(mo)
 		end
 	else


### PR DESCRIPTION
The MT_STINGALERT code accidentally clears the old variable for the sting alert pointer, which somehow lets it come back from the dead when someone joins mid-game?

This also fixes the sting alert disappearing forever when a player respawns.

Edit: The sting alert doesn't come back from the dead, but rather rs.stingAlertMobj (now an invalid mobj) becomes nil when synced in netgames, which makes the client erroneously respawn the sting alert. Since it repeatedly calls RNG, this triggers the desync.